### PR TITLE
Do not use dotimes-unroll macro for dot production

### DIFF
--- a/src/dotprod.lisp
+++ b/src/dotprod.lisp
@@ -7,7 +7,6 @@
                           :string-designator)
   (:import-from :cl3a.utilities
                 :min-factor
-                :dotimes-unroll
                 :dvvs-calc-within-L1
                 :lvvs-calc-within-L1
                 :different-length-warn)
@@ -17,13 +16,35 @@
 
 (defmacro v*v-ker (val-type p n nv va vb)
   "Dot production between vectors va and vb"
-  (with-gensyms (nvec res i)
+  (with-gensyms (nvec n5 res i maxi i1 i2 i3 i4)
     `(let* ((,nvec (min ,nv (the fixnum (+ ,p ,n))))
-            (,res (coerce 0.0 ',val-type)))
-       (declare (type fixnum ,nvec)
+            (,n5 (min-factor ,nvec 5))
+            (,res (coerce 0.0 (quote ,val-type))))
+       (declare (type fixnum ,nvec ,n5)
                 (type ,val-type ,res))
-       (dotimes-unroll (,i ,p 5 ,nvec)
-         (incf ,res (* (aref ,va ,i) (aref ,vb ,i))))
+       ;; Do NOT use dotimes-unroll macro for speed
+       (cond
+         ((< ,nvec 5) (do ((,i ,p (+ ,i 1)))
+                          ((>= ,i ,nvec))
+                        (incf ,res (* (aref ,va ,i) (aref ,vb ,i)))))
+         (t (let ((,maxi
+                   (do ((,i ,p (+ ,i 5))
+                        (,i1 (the fixnum (+ ,p 1)) (the fixnum (+ ,i1 5)))
+                        (,i2 (the fixnum (+ ,p 2)) (the fixnum (+ ,i2 5)))
+                        (,i3 (the fixnum (+ ,p 3)) (the fixnum (+ ,i3 5)))
+                        (,i4 (the fixnum (+ ,p 4)) (the fixnum (+ ,i4 5))))
+                       ((>= ,i ,n5) ,i)
+                     (incf ,res
+                           (+ (* (aref ,va ,i)  (aref ,vb ,i))
+                              (* (aref ,va ,i1) (aref ,vb ,i1))
+                              (* (aref ,va ,i2) (aref ,vb ,i2))
+                              (* (aref ,va ,i3) (aref ,vb ,i3))
+                              (* (aref ,va ,i4) (aref ,vb ,i4)))))))
+              (declare (type fixnum ,maxi))
+              (when (< ,maxi ,nvec)
+                (do ((,i ,maxi (+ ,i 1)))
+                    ((>= ,i ,nvec))
+                  (incf ,res (* (aref ,va ,i) (aref ,vb ,i))))))))
        ,res)))
 
 


### PR DESCRIPTION
Do not use dotimes-unroll macro for dot production for speed
